### PR TITLE
Added scripts to deploy and activate yield farming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+# python ignores
 __pycache__
 .history
 .hypothesis/
+.venv/
 build/
 reports/
+
+
+# js ignores
+.env
+node_modules/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Keep the following in mind when using the `MultiReward` contract:
 * [ganache-cli](https://github.com/trufflesuite/ganache-cli) - tested with version [6.12.1](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.12.1)
 * [brownie-token-tester](https://github.com/iamdefinitelyahuman/brownie-token-tester)
 
+## Environment Setup
+
+```
+npm run preinstall
+virtualenv .venv 
+source .venv/bin/activate
+pip install -r requirements.txt
+npm install
+```
+
 ## Testing
 
 The test suite is broadly split between [unit](tests/unitary) and [integration](tests/integration) tests.
@@ -55,10 +65,25 @@ brownie test tests/integration
 
 ## Deployment
 
-To deploy the contracts, first modify the [deployment script](scripts/deploy.py) to unlock the account you wish to deploy from. Then:
+To compile before deploying:
 
 ```bash
-brownie run deploy --network mainnet
+brownie compile
+```
+
+First step of deployment:
+```bash
+npm run deployMultirewards [mainnet|testnet]
+```
+
+We need to add the address of the token we are rewarding and the period. Assumed to be just VEX for now. Rewards are not live yet when this function is called.
+```bash
+npm run addReward [mainnet|testnet] [Multirewards address] [Duration in days]
+```
+
+Lastly, we need to `ERC20::approve` the amount to be rewarded and transfer it to the `Multirewards` contract address. Rewards are live once this function is called.
+```bash
+npm run notifyRewardAmount [mainnet|testnet] [Multirewards address] [Reward amount (excluding 18 decimals)]
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,5 +1,31 @@
 {
-    "scripts": {
-      "preinstall": "npm i -g ganache-cli@6.12.1"
-    }
+  "scripts": {
+    "preinstall": "npm i -g ganache-cli@6.12.1",
+    "compile": "brownie compile",
+    "deployMultirewards": "node scripts/deployMultirewards",
+    "addReward": "node scripts/addReward",
+    "notifyRewardAmount": "node scripts/notifyRewardAmount"
+  },
+  "name": "multi-rewards",
+  "description": "A modified version of the [Synthetix](https://github.com/Synthetixio/synthetix) staking rewards contract, allowing for multiple rewards tokens. Designed for use with [Curve.fi](https://github.com/curvefi) liquidity gauges.",
+  "version": "1.0.0",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vexchange/multi-rewards.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/vexchange/multi-rewards/issues"
+  },
+  "homepage": "https://github.com/vexchange/multi-rewards#readme",
+  "dependencies": {
+    "dotenv": "^10.0.0",
+    "thorify": "1.5.6",
+    "web3": "1.3.5"
   }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/vexchange/multi-rewards#readme",
   "dependencies": {
     "dotenv": "^10.0.0",
+    "readline-sync": "^1.4.10",
     "thorify": "1.5.6",
     "web3": "1.3.5"
   }

--- a/scripts/addReward.js
+++ b/scripts/addReward.js
@@ -4,6 +4,7 @@ const thorify = require("thorify").thorify;
 const Web3 = require("web3");
 const Multirewards = require(config.pathToMultirewardsJson);
 const assert = require('assert');
+const readlineSync = require('readline-sync');
 
 let network = null;
 let multirewardsAddress = null;
@@ -16,9 +17,8 @@ if (process.argv.length < 5)
 } 
 else
 {
-    if (process.argv[2] == "mainnet") network = config.network.mainnet;
-    else if (process.argv[2] == "testnet") network = config.network.testnet;
-    else {
+    network = config.network[process.argv[2]];
+    if (network === undefined) {
         console.error("Invalid network specified");
         process.exit(1);
     }
@@ -50,6 +50,12 @@ addReward = async() =>
                                             .call()) ;
         console.log("For a duration of:", duration, "seconds");
 
+        if (network.name == "mainnet")
+        {
+            let input = readlineSync.question("Confirm you want to deploy this on the MAINNET? (y/n) ");
+            if (input != 'y') process.exit(1);
+        }
+        
         await multirewardsContract
                 .methods
                 .addReward(

--- a/scripts/addReward.js
+++ b/scripts/addReward.js
@@ -1,0 +1,73 @@
+// ES5 style
+const config = require("./deploymentConfig");
+const thorify = require("thorify").thorify;
+const Web3 = require("web3");
+const Multirewards = require(config.pathToMultirewardsJson);
+const assert = require('assert');
+
+let network = null;
+let multirewardsAddress = null;
+let duration = null;
+
+if (process.argv.length < 5) 
+{
+    console.error("Usage: node scripts/addReward [mainnet|testnet] [Multirewards address] [Duration in days]");
+    process.exit(1);
+} 
+else
+{
+    if (process.argv[2] == "mainnet") network = config.network.mainnet;
+    else if (process.argv[2] == "testnet") network = config.network.testnet;
+    else {
+        console.error("Invalid network specified");
+        process.exit(1);
+    }
+
+    multirewardsAddress = process.argv[3];
+    duration = parseInt(process.argv[4]) * 86400;
+}
+
+const web3 = thorify(new Web3(), network.rpcUrl);
+web3.eth.accounts.wallet.add(config.privateKey);
+
+addReward = async() =>
+{
+    // This is the address associated with the private key
+    const walletAddress = web3.eth.accounts.wallet[0].address;
+
+    console.log("Using wallet address:", walletAddress);
+    console.log("Using RPC:", web3.eth.currentProvider.RESTHost);
+
+    try
+    {
+        let transactionReceipt = null;
+        const multirewardsContract = new web3.eth.Contract(Multirewards.abi, multirewardsAddress);
+
+        console.log("Attempting to add reward for multireward address:", multirewardsAddress);
+        console.log("For staking token:", await multirewardsContract
+                                            .methods
+                                            .stakingToken()
+                                            .call()) ;
+        console.log("For a duration of:", duration, "seconds");
+
+        await multirewardsContract
+                .methods
+                .addReward(
+                    network.vexAddress, // Assuming we are only giving VEX for now
+                    walletAddress, // Assuming owner to be the distributor
+                    duration
+                )
+        .send({ from: walletAddress })
+        .on("receipt", (receipt) => {
+            transactionReceipt = receipt;
+        });
+
+        console.log("Transaction Hash:", transactionReceipt.transactionHash);
+    } 
+    catch(error)
+    {
+        console.log("Deployment failed with:", error)
+    }
+}
+
+addReward();

--- a/scripts/deployMultirewards.js
+++ b/scripts/deployMultirewards.js
@@ -4,6 +4,7 @@ const thorify = require("thorify").thorify;
 const Web3 = require("web3");
 const Multirewards = require(config.pathToMultirewardsJson);
 const assert = require('assert');
+const readlineSync = require('readline-sync');
 
 let network = null;
 let stakingTokenAddress = null;
@@ -15,9 +16,8 @@ if (process.argv.length < 4)
 } 
 else
 {
-    if (process.argv[2] == "mainnet") network = config.network.mainnet;
-    else if (process.argv[2] == "testnet") network = config.network.testnet;
-    else {
+    network = config.network[process.argv[2]];
+    if (network === undefined) {
         console.error("Invalid network specified");
         process.exit(1);
     }
@@ -65,6 +65,12 @@ deployMultirewards = async() =>
 
         console.log("Attempting to deploy contract:", config.pathToMultirewardsJson);
         console.log("For staking token:", stakingTokenAddress);
+
+        if (network.name == "mainnet")
+        {
+            let input = readlineSync.question("Confirm you want to deploy this on the MAINNET? (y/n) ");
+            if (input != 'y') process.exit(1);
+        }
 
         const multirewardsContract = new web3.eth.Contract(Multirewards.abi);
         await multirewardsContract.deploy({ 

--- a/scripts/deployMultirewards.js
+++ b/scripts/deployMultirewards.js
@@ -1,0 +1,93 @@
+// ES5 style
+const config = require("./deploymentConfig");
+const thorify = require("thorify").thorify;
+const Web3 = require("web3");
+const Multirewards = require(config.pathToMultirewardsJson);
+const assert = require('assert');
+
+let network = null;
+let stakingTokenAddress = null;
+
+if (process.argv.length < 4) 
+{
+    console.error("Usage: node scripts/deployMultirewards [mainnet|testnet] [stakingTokenAddress]");
+    process.exit(1);
+} 
+else
+{
+    if (process.argv[2] == "mainnet") network = config.network.mainnet;
+    else if (process.argv[2] == "testnet") network = config.network.testnet;
+    else {
+        console.error("Invalid network specified");
+        process.exit(1);
+    }
+
+    stakingTokenAddress = process.argv[3];
+}
+
+const web3 = thorify(new Web3(), network.rpcUrl);
+web3.eth.accounts.wallet.add(config.privateKey);
+
+renounceMastership = async(contractAddress) => 
+{
+    console.log("Renouncing Mastership");
+
+    const SET_MASTER_SELECTOR = web3.eth.abi.encodeFunctionSignature("setMaster(address,address)");
+
+    // This address is the same for both mainnet and testnet
+    const PROTOTYPE_CONTRACT_ADDRESS = "0x000000000000000000000050726f746f74797065";
+
+    const data = web3.eth.abi.encodeParameters(
+       ["address", "address"],
+       [contractAddress, "0x0000000000000000000000000000000000000000"],
+    ).slice(2); // slicing to get rid of the '0x' in the beginning
+
+    await web3.eth.sendTransaction({
+        to: PROTOTYPE_CONTRACT_ADDRESS,
+        data: SET_MASTER_SELECTOR + data,
+        from: web3.eth.accounts.wallet[0].address
+    }).on("receipt", (receipt) => {
+        console.log("Mastership successfully renounced, txid: ", receipt.transactionHash);
+    });
+}
+
+deployMultirewards = async() =>
+{
+    // This is the address associated with the private key
+    const walletAddress = web3.eth.accounts.wallet[0].address;
+
+    console.log("Using wallet address:", walletAddress);
+    console.log("Using RPC:", web3.eth.currentProvider.RESTHost);
+
+    try
+    {
+        let transactionReceipt = null;
+
+        console.log("Attempting to deploy contract:", config.pathToMultirewardsJson);
+        console.log("For staking token:", stakingTokenAddress);
+
+        const multirewardsContract = new web3.eth.Contract(Multirewards.abi);
+        await multirewardsContract.deploy({ 
+            data: Multirewards.bytecode,
+            arguments: [ 
+                         walletAddress, 
+                         stakingTokenAddress 
+                       ]
+        })
+        .send({ from: walletAddress })
+        .on("receipt", (receipt) => {
+            transactionReceipt = receipt;
+        });
+
+        console.log("Transaction Hash:", transactionReceipt.transactionHash);
+        console.log("Contract Successfully deployed at address:", transactionReceipt.contractAddress);
+
+        await renounceMastership(transactionReceipt.contractAddress);
+    } 
+    catch(error)
+    {
+        console.log("Deployment failed with:", error)
+    }
+}
+
+deployMultirewards();

--- a/scripts/deploymentConfig.js
+++ b/scripts/deploymentConfig.js
@@ -4,10 +4,12 @@ module.exports = {
     privateKey: process.env.PRIVATE_KEY,
     network: {
         mainnet: {
+            name: "mainnet",
             rpcUrl: "https://mainnet.veblocks.net/",
             vexAddress: ""
         },
         testnet: {
+            name: "testnet",
             rpcUrl: "https://testnet.veblocks.net/",
             vexAddress: ""
         }

--- a/scripts/deploymentConfig.js
+++ b/scripts/deploymentConfig.js
@@ -1,0 +1,17 @@
+require("dotenv").config({ path: "./.env" })
+
+module.exports = {
+    privateKey: process.env.PRIVATE_KEY,
+    network: {
+        mainnet: {
+            rpcUrl: "https://mainnet.veblocks.net/",
+            vexAddress: ""
+        },
+        testnet: {
+            rpcUrl: "https://testnet.veblocks.net/",
+            vexAddress: ""
+        }
+    },
+    pathToMultirewardsJson: "../build/contracts/MultiRewards.json",
+    pathToIERC20Json: "../build/contracts/IERC20.json",
+};

--- a/scripts/notifyRewardAmount.js
+++ b/scripts/notifyRewardAmount.js
@@ -1,0 +1,85 @@
+// ES5 style
+const config = require("./deploymentConfig");
+const thorify = require("thorify").thorify;
+const Web3 = require("web3");
+const Multirewards = require(config.pathToMultirewardsJson);
+const IERC20 = require(config.pathToIERC20Json);
+const assert = require('assert');
+
+let network = null;
+let multirewardsAddress = null;
+let rewardAmount = null;
+
+if (process.argv.length < 5) 
+{
+    console.error("Usage: node scripts/notifyRewardAmount [mainnet|testnet] [Multirewards address] [Reward amount (excluding 18 decimals)]");
+    process.exit(1);
+} 
+else
+{
+    if (process.argv[2] == "mainnet") network = config.network.mainnet;
+    else if (process.argv[2] == "testnet") network = config.network.testnet;
+    else {
+        console.error("Invalid network specified");
+        process.exit(1);
+    }
+
+    multirewardsAddress = process.argv[3];
+    rewardAmount = Web3.utils.toWei(process.argv[4]);
+}
+
+const web3 = thorify(new Web3(), network.rpcUrl);
+web3.eth.accounts.wallet.add(config.privateKey);
+
+notifyRewardAmount = async() =>
+{
+    // This is the address associated with the private key
+    const walletAddress = web3.eth.accounts.wallet[0].address;
+
+    console.log("Using wallet address:", walletAddress);
+    console.log("Using RPC:", web3.eth.currentProvider.RESTHost);
+
+    try
+    {
+        let transactionReceipt = null;
+        const multirewardsContract = new web3.eth.Contract(Multirewards.abi, multirewardsAddress);
+        const vexERC20 = new web3.eth.Contract(IERC20.abi, network.vexAddress);
+
+        console.log("Attempting ERC20 approve for transfer, amount:", rewardAmount);        
+
+        await vexERC20
+                .methods
+                .approve(multirewardsAddress,
+                         rewardAmount)
+                .send({ from: walletAddress })
+                .on("receipt", (receipt) => {
+                    transactionReceipt = receipt;
+                });;
+
+        console.log("Approve successful, tx hash:", transactionReceipt.transactionHash);
+        console.log("Attempting notifyRewardAmount for multireward address:", multirewardsAddress);
+        console.log("For staking token:", await multirewardsContract
+                                            .methods
+                                            .stakingToken()
+                                            .call());
+
+        await multirewardsContract
+                .methods
+                .notifyRewardAmount(
+                    network.vexAddress, // Assuming we are only giving VEX for now
+                    rewardAmount
+                )
+        .send({ from: walletAddress })
+        .on("receipt", (receipt) => {
+            transactionReceipt = receipt;
+        });
+
+        console.log("Transaction Hash:", transactionReceipt.transactionHash);
+    } 
+    catch(error)
+    {
+        console.log("Deployment failed with:", error)
+    }
+}
+
+notifyRewardAmount();

--- a/scripts/notifyRewardAmount.js
+++ b/scripts/notifyRewardAmount.js
@@ -5,6 +5,7 @@ const Web3 = require("web3");
 const Multirewards = require(config.pathToMultirewardsJson);
 const IERC20 = require(config.pathToIERC20Json);
 const assert = require('assert');
+const readlineSync = require('readline-sync');
 
 let network = null;
 let multirewardsAddress = null;
@@ -17,9 +18,8 @@ if (process.argv.length < 5)
 } 
 else
 {
-    if (process.argv[2] == "mainnet") network = config.network.mainnet;
-    else if (process.argv[2] == "testnet") network = config.network.testnet;
-    else {
+    network = config.network[process.argv[2]];
+    if (network === undefined) {
         console.error("Invalid network specified");
         process.exit(1);
     }
@@ -47,6 +47,12 @@ notifyRewardAmount = async() =>
 
         console.log("Attempting ERC20 approve for transfer, amount:", rewardAmount);        
 
+        if (network.name == "mainnet")
+        {
+            let input = readlineSync.question("Confirm you want to deploy this on the MAINNET? (y/n) ");
+            if (input != 'y') process.exit(1);
+        }
+        
         await vexERC20
                 .methods
                 .approve(multirewardsAddress,


### PR DESCRIPTION
1. We're not changing the dev toolchain of compiling and testing. Still using `brownie` which is python based. Initially I wanted to try deploying in python, but there is no framework for VeChain in python. Vechain is also incompatible with brownie because brownie assumes RPC while VeChain uses REST. Hence we only add the deployment part which uses js.

2. Introduced the functions we need to perform to get it going first. When we need the other functions, like setRewardsDuration, we will write the script when the time comes. 

3. Note to ourselves: need to transfer ownership and set rewardDistributor to the timelock address when it's time to handover to governance 